### PR TITLE
feat: change labels to single purpose

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -102,33 +102,37 @@ Deployment specific labels
 {{/*
 Selector labels
 */}}
+{{- define "voltaserve.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "voltaserve.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
 {{- define "voltaserve-api.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "voltaserve.name" . }}-api
-app.kubernetes.io/instance: {{ .Release.Name }}-api
+{{ include "voltaserve.selectorLabels" . }}
+app.kubernetes.io/component: api
 {{- end }}
 {{- define "voltaserve-conversion.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "voltaserve.name" . }}-conversion
-app.kubernetes.io/instance: {{ .Release.Name }}-conversion
+{{ include "voltaserve.selectorLabels" . }}
+app.kubernetes.io/component: conversion
 {{- end }}
 {{- define "voltaserve-ui.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "voltaserve.name" . }}-ui
-app.kubernetes.io/instance: {{ .Release.Name }}-ui
+{{ include "voltaserve.selectorLabels" . }}
+app.kubernetes.io/component: ui
 {{- end }}
 {{- define "voltaserve-idp.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "voltaserve.name" . }}-idp
-app.kubernetes.io/instance: {{ .Release.Name }}-idp
+{{ include "voltaserve.selectorLabels" . }}
+app.kubernetes.io/component: idp
 {{- end }}
 {{- define "voltaserve-language.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "voltaserve.name" . }}-language
-app.kubernetes.io/instance: {{ .Release.Name }}-language
+{{ include "voltaserve.selectorLabels" . }}
+app.kubernetes.io/component: language
 {{- end }}
 {{- define "voltaserve-mosaic.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "voltaserve.name" . }}-mosaic
-app.kubernetes.io/instance: {{ .Release.Name }}-mosaic
+{{ include "voltaserve.selectorLabels" . }}
+app.kubernetes.io/component: mosaic
 {{- end }}
 {{- define "voltaserve-webdav.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "voltaserve.name" . }}-webdav
-app.kubernetes.io/instance: {{ .Release.Name }}-webdav
+{{ include "voltaserve.selectorLabels" . }}
+app.kubernetes.io/component: webdav
 {{- end }}
 
 {{/*

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -24,6 +24,32 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 
 {{/*
+Create the component specific names.
+We truncate the common name more because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "voltaserve-api.fullname" -}}
+{{- printf "%s-api" ( include "voltaserve.fullname" . | trunc 50 ) }}
+{{- end }}
+{{- define "voltaserve-idp.fullname" -}}
+{{- printf "%s-idp" ( include "voltaserve.fullname" . | trunc 50 ) }}
+{{- end }}
+{{- define "voltaserve-ui.fullname" -}}
+{{- printf "%s-ui" ( include "voltaserve.fullname" . | trunc 50 ) }}
+{{- end }}
+{{- define "voltaserve-language.fullname" -}}
+{{- printf "%s-language" ( include "voltaserve.fullname" . | trunc 50 ) }}
+{{- end }}
+{{- define "voltaserve-conversion.fullname" -}}
+{{- printf "%s-conversion" ( include "voltaserve.fullname" . | trunc 50 ) }}
+{{- end }}
+{{- define "voltaserve-mosaic.fullname" -}}
+{{- printf "%s-mosaic" ( include "voltaserve.fullname" . | trunc 50 ) }}
+{{- end }}
+{{- define "voltaserve-webdav.fullname" -}}
+{{- printf "%s-webdav" ( include "voltaserve.fullname" . | trunc 50 ) }}
+{{- end }}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "voltaserve.chart" -}}

--- a/templates/api/configmap.yaml
+++ b/templates/api/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "voltaserve.fullname" . }}-api
+  name: {{ include "voltaserve-api.fullname" . }}
 data:
   {{- if .Values.api.envs }}
     {{- range $k,$v := .Values.api.envs }}
@@ -13,9 +13,9 @@ data:
   SMTP_SENDER_ADDRESS: {{ .Values.general.smtp.SMTP_SENDER_ADDRESS | quote }}
   SMTP_SENDER_NAME: {{ .Values.general.smtp.SMTP_SENDER_NAME | quote }}
   SMTP_SECURE: {{ .Values.general.smtp.SMTP_SECURE | quote }}
-  CONVERSION_URL: http://{{ include "voltaserve.fullname" . }}-conversion.{{.Release.Namespace}}.svc.cluster.local:{{ .Values.conversion.service.port }}
-  LANGUAGE_URL: http://{{ include "voltaserve.fullname" . }}-language.{{.Release.Namespace}}.svc.cluster.local:{{ .Values.language.service.port }}
-  MOSAIC_URL: http://{{ include "voltaserve.fullname" . }}-mosaic.{{.Release.Namespace}}.svc.cluster.local:{{ .Values.mosaic.service.port }}
+  CONVERSION_URL: http://{{ include "voltaserve-conversion.fullname" . }}.{{.Release.Namespace}}.svc.cluster.local:{{ .Values.conversion.service.port }}
+  LANGUAGE_URL: http://{{ include "voltaserve-language.fullname" . }}.{{.Release.Namespace}}.svc.cluster.local:{{ .Values.language.service.port }}
+  MOSAIC_URL: http://{{ include "voltaserve-mosaic.fullname" . }}.{{.Release.Namespace}}.svc.cluster.local:{{ .Values.mosaic.service.port }}
   {{- if .Values.ingress.enabled }}
   PUBLIC_UI_URL: https://{{ .Values.ingress.host }}
   SECURITY_CORS_ORIGINS: https://{{ .Values.ingress.host }}

--- a/templates/api/deployment.yaml
+++ b/templates/api/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "voltaserve.fullname" . }}-api
+  name: {{ include "voltaserve-api.fullname" . }}-api
   labels:
     {{- include "voltaserve-api.labels" . | nindent 4 }}
 spec:
@@ -36,7 +36,7 @@ spec:
       {{- end }}
       {{- end }}
       containers:
-        - name: {{ include "voltaserve.fullname" . }}-api
+        - name: main
           {{- if .Values.api.deployment.security }}
           {{- if .Values.api.deployment.security.podSecurityContext }} 
           securityContext:
@@ -69,9 +69,9 @@ spec:
           {{- end }}
           envFrom:
           - configMapRef:
-              name: {{ include "voltaserve.fullname" . }}-api
+              name: {{ include "voltaserve-api.fullname" . }}
           - secretRef:
-              name: {{ include "voltaserve.fullname" . }}-api
+              name: {{ include "voltaserve-api.fullname" . }}
       {{- with .Values.api.deployment.volumes }}
       volumes:
         {{- toYaml . | nindent 8 }}

--- a/templates/api/secret.yaml
+++ b/templates/api/secret.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "voltaserve.fullname" . }}-api
+  name: {{ include "voltaserve-api.fullname" . }}
 type: Opaque
 data:
 {{- range $k,$v := $root }}

--- a/templates/api/service.yaml
+++ b/templates/api/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "voltaserve.fullname" . }}-api
+  name: {{ include "voltaserve-api.fullname" . }}
   labels:
     {{- include "voltaserve-api.labels" . | nindent 4 }}
 spec:

--- a/templates/conversion/configmap.yaml
+++ b/templates/conversion/configmap.yaml
@@ -1,16 +1,16 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "voltaserve.fullname" . }}-conversion
+  name: {{ include "voltaserve-conversion.fullname" . }}
 data:
   {{- if .Values.conversion.envs }}
     {{- range $k,$v := .Values.conversion.envs }}
       {{$k }}: {{ default "" $v | quote }}
     {{- end }}
   {{- end }}
-  API_URL: http://{{ include "voltaserve.fullname" . }}-api.{{.Release.Namespace}}.svc.cluster.local:{{ .Values.api.service.port }}
-  LANGUAGE_URL: http://{{ include "voltaserve.fullname" . }}-language.{{.Release.Namespace}}.svc.cluster.local:{{ .Values.language.service.port }}
-  MOSAIC_URL: http://{{ include "voltaserve.fullname" . }}-mosaic.{{.Release.Namespace}}.svc.cluster.local:{{ .Values.mosaic.service.port }}
+  API_URL: http://{{ include "voltaserve-api.fullname" . }} .{{.Release.Namespace}}.svc.cluster.local:{{ .Values.api.service.port }}
+  LANGUAGE_URL: http://{{ include "voltaserve-language.fullname" . }}.{{.Release.Namespace}}.svc.cluster.local:{{ .Values.language.service.port }}
+  MOSAIC_URL: http://{{ include "voltaserve-mosaic.fullname" . }}.{{.Release.Namespace}}.svc.cluster.local:{{ .Values.mosaic.service.port }}
   {{- if .Values.minio.enabled }}
   S3_URL: {{ include "voltaserve.fullname" . }}-minio.{{ .Release.Namespace }}.svc.cluster.local:9000
   {{- else }}

--- a/templates/conversion/deployment.yaml
+++ b/templates/conversion/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "voltaserve.fullname" . }}-conversion
+  name: {{ include "voltaserve-conversion.fullname" . }}
   labels:
     {{- include "voltaserve-conversion.labels" . | nindent 4 }}
 spec:
@@ -36,7 +36,7 @@ spec:
       {{- end }}
       {{- end }}
       containers:
-        - name: {{ include "voltaserve.fullname" . }}-conversion
+        - name: main
           {{- if .Values.conversion.deployment.security }}
           {{- if .Values.conversion.deployment.security.podSecurityContext }} 
           securityContext:
@@ -69,9 +69,9 @@ spec:
           {{- end }}
           envFrom:
           - configMapRef:
-              name: {{ include "voltaserve.fullname" . }}-conversion
+              name: {{ include "voltaserve-conversion.fullname" . }}
           - secretRef:
-              name: {{ include "voltaserve.fullname" . }}-conversion
+              name: {{ include "voltaserve-conversion.fullname" . }}
       {{- with .Values.conversion.deployment.volumes }}
       volumes:
         {{- toYaml . | nindent 8 }}

--- a/templates/conversion/secret.yaml
+++ b/templates/conversion/secret.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "voltaserve.fullname" . }}-conversion
+  name: {{ include "voltaserve-conversion.fullname" . }}
 type: Opaque
 data:
 {{- range $k,$v := $root }}

--- a/templates/conversion/service.yaml
+++ b/templates/conversion/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "voltaserve.fullname" . }}-conversion
+  name: {{ include "voltaserve-conversion.fullname" . }}
   labels:
     {{- include "voltaserve-conversion.labels" . | nindent 4 }}
 spec:

--- a/templates/idp/configmap.yaml
+++ b/templates/idp/configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "voltaserve.fullname" . }}-idp
+  name: {{ include "voltaserve-idp.fullname" . }}
 data:
   {{- if .Values.idp.envs }}
     {{- range $k,$v := .Values.idp.envs }}

--- a/templates/idp/deployment.yaml
+++ b/templates/idp/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "voltaserve.fullname" . }}-idp
+  name: {{ include "voltaserve-idp.fullname" . }}
   labels:
     {{- include "voltaserve-idp.labels" . | nindent 4 }}
 spec:
@@ -36,7 +36,7 @@ spec:
       {{- end }}
       {{- end }}
       containers:
-        - name: {{ include "voltaserve.fullname" . }}-idp
+        - name: main
           {{- if .Values.idp.deployment.security }}
           {{- if .Values.idp.deployment.security.podSecurityContext }} 
           securityContext:
@@ -69,9 +69,9 @@ spec:
           {{- end }}
           envFrom:
           - configMapRef:
-              name: {{ include "voltaserve.fullname" . }}-idp
+              name: {{ include "voltaserve-idp.fullname" . }}
           - secretRef:
-              name: {{ include "voltaserve.fullname" . }}-idp
+              name: {{ include "voltaserve-idp.fullname" . }}
       {{- with .Values.idp.deployment.volumes }}
       volumes:
         {{- toYaml . | nindent 8 }}

--- a/templates/idp/secret.yaml
+++ b/templates/idp/secret.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "voltaserve.fullname" . }}-idp
+  name: {{ include "voltaserve-idp.fullname" . }}
 type: Opaque
 data:
 {{- range $k,$v := $root }}

--- a/templates/idp/service.yaml
+++ b/templates/idp/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "voltaserve.fullname" . }}-idp
+  name: {{ include "voltaserve-idp.fullname" . }}
   labels:
     {{- include "voltaserve-idp.labels" . | nindent 4 }}
 spec:

--- a/templates/language/deployment.yaml
+++ b/templates/language/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "voltaserve.fullname" . }}-language
+  name: {{ include "voltaserve-language.fullname" . }}
   labels:
     {{- include "voltaserve-language.labels" . | nindent 4 }}
 spec:
@@ -34,7 +34,7 @@ spec:
       {{- end }}
       {{- end }}
       containers:
-        - name: {{ include "voltaserve.fullname" . }}-language
+        - name: main
           {{- if .Values.language.deployment.security }}
           {{- if .Values.language.deployment.security.podSecurityContext }} 
           securityContext:

--- a/templates/language/service.yaml
+++ b/templates/language/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "voltaserve.fullname" . }}-language
+  name: {{ include "voltaserve-language.fullname" . }}
   labels:
     {{- include "voltaserve-language.labels" . | nindent 4 }}
 spec:

--- a/templates/mosaic/configmap.yaml
+++ b/templates/mosaic/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "voltaserve.fullname" . }}-mosaic
+  name: {{ include "voltaserve-mosaic.fullname" . }}
 data:
   {{- if .Values.mosaic.envs }}
     {{- range $k,$v := .Values.mosaic.envs }}

--- a/templates/mosaic/deployment.yaml
+++ b/templates/mosaic/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "voltaserve.fullname" . }}-mosaic
+  name: {{ include "voltaserve-mosaic.fullname" . }}
   labels:
     {{- include "voltaserve-mosaic.labels" . | nindent 4 }}
 spec:
@@ -36,7 +36,7 @@ spec:
       {{- end }}
       {{- end }}
       containers:
-        - name: {{ include "voltaserve.fullname" . }}-mosaic
+        - name: main
           {{- if .Values.mosaic.deployment.security }}
           {{- if .Values.mosaic.deployment.security.podSecurityContext }} 
           securityContext:
@@ -69,9 +69,9 @@ spec:
           {{- end }}
           envFrom:
           - configMapRef:
-              name: {{ include "voltaserve.fullname" . }}-mosaic
+              name: {{ include "voltaserve-mosaic.fullname" . }}
           - secretRef:
-              name: {{ include "voltaserve.fullname" . }}-mosaic
+              name: {{ include "voltaserve-mosaic.fullname" . }}
       {{- with .Values.mosaic.deployment.volumes }}
       volumes:
         {{- toYaml . | nindent 8 }}

--- a/templates/mosaic/secret.yaml
+++ b/templates/mosaic/secret.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "voltaserve.fullname" . }}-mosaic
+  name: {{ include "voltaserve-mosaic.fullname" . }}
 type: Opaque
 data:
 {{- range $k,$v := $root }}

--- a/templates/mosaic/service.yaml
+++ b/templates/mosaic/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "voltaserve.fullname" . }}-mosaic
+  name: {{ include "voltaserve-mosaic.fullname" . }}
   labels:
     {{- include "voltaserve-mosaic.labels" . | nindent 4 }}
 spec:

--- a/templates/ui/configmap.yaml
+++ b/templates/ui/configmap.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "voltaserve.fullname" . }}-ui
+  name: {{ include "voltaserve-ui.fullname" . }}
 data:
   {{- if .Values.ui.envs }}
     {{- range $k,$v := .Values.ui.envs }}
       {{$k }}: {{ default "" $v | quote }}
     {{- end }}
   {{- end }}
-  API_URL: http://{{ include "voltaserve.fullname" . }}-api.{{.Release.Namespace}}.svc.cluster.local:{{ .Values.api.service.port }}
-  IDP_URL: http://{{ include "voltaserve.fullname" . }}-idp.{{.Release.Namespace}}.svc.cluster.local:{{ .Values.idp.service.port }}
+  API_URL: http://{{ include "voltaserve-api.fullname" . }}.{{.Release.Namespace}}.svc.cluster.local:{{ .Values.api.service.port }}
+  IDP_URL: http://{{ include "voltaserve-idp.fullname" . }}.{{.Release.Namespace}}.svc.cluster.local:{{ .Values.idp.service.port }}

--- a/templates/ui/deployment.yaml
+++ b/templates/ui/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "voltaserve.fullname" . }}-ui
+  name: {{ include "voltaserve-ui.fullname" . }}
   labels:
     {{- include "voltaserve-ui.labels" . | nindent 4 }}
 spec:
@@ -35,7 +35,7 @@ spec:
       {{- end }}
       {{- end }}
       containers:
-        - name: {{ include "voltaserve.fullname" . }}-ui
+        - name: main
           {{- if .Values.ui.deployment.security }}
           {{- if .Values.ui.deployment.security.podSecurityContext }} 
           securityContext:
@@ -68,7 +68,7 @@ spec:
           {{- end }}
           envFrom:
           - configMapRef:
-              name: {{ include "voltaserve.fullname" . }}-ui
+              name: {{ include "voltaserve-ui.fullname" . }}
       {{- with .Values.ui.deployment.volumes }}
       volumes:
         {{- toYaml . | nindent 8 }}

--- a/templates/ui/service.yaml
+++ b/templates/ui/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "voltaserve.fullname" . }}-ui
+  name: {{ include "voltaserve-ui.fullname" . }}
   labels:
     {{- include "voltaserve-ui.labels" . | nindent 4 }}
 spec:

--- a/templates/webdav/configmap.yaml
+++ b/templates/webdav/configmap.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "voltaserve.fullname" . }}-webdav
+  name: {{ include "voltaserve-webdav.fullname" . }}
 data:
   {{- if .Values.webdav.envs }}
     {{- range $k,$v := .Values.webdav.envs }}
       {{$k }}: {{ default "" $v | quote }}
     {{- end }}
   {{- end }}
-  IDP_URL: http://{{ include "voltaserve.fullname" . }}-idp.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.idp.service.port }}
-  API_URL: http://{{ include "voltaserve.fullname" . }}-api.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.api.service.port }}
+  IDP_URL: http://{{ include "voltaserve-idp.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.idp.service.port }}
+  API_URL: http://{{ include "voltaserve-api.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.api.service.port }}
 

--- a/templates/webdav/deployment.yaml
+++ b/templates/webdav/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "voltaserve.fullname" . }}-webdav
+  name: {{ include "voltaserve-webdav.fullname" . }}
   labels:
     {{- include "voltaserve-webdav.labels" . | nindent 4 }}
 spec:
@@ -35,7 +35,7 @@ spec:
       {{- end }}
       {{- end }}
       containers:
-        - name: {{ include "voltaserve.fullname" . }}-webdav
+        - name: main
           {{- if .Values.webdav.deployment.security }}
           {{- if .Values.webdav.deployment.security.podSecurityContext }} 
           securityContext:
@@ -68,7 +68,7 @@ spec:
           {{- end }}
           envFrom:
           - configMapRef:
-              name: {{ include "voltaserve.fullname" . }}-webdav
+              name: {{ include "voltaserve-webdav.fullname" . }}
       {{- with .Values.webdav.deployment.volumes }}
       volumes:
         {{- toYaml . | nindent 8 }}

--- a/templates/webdav/service.yaml
+++ b/templates/webdav/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "voltaserve.fullname" . }}-webdav
+  name: {{ include "voltaserve-webdav.fullname" . }}
   labels:
     {{- include "voltaserve-webdav.labels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
This changes the labels to have a single purpose:
- name -> the name of the application as a whole
- instance -> the release of the application
- component -> the component of the application, to differentiate different microservices

Closes: #2 